### PR TITLE
Implement mobile joystick control

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,11 +431,11 @@
         
         <div class="mobile-controls">
             <div class="controls-wrapper">
+                <button class="start-btn" id="startBtn">START</button>
                 <div class="joystick-container" id="joystickContainer">
                     <div class="joystick-base"></div>
                     <div class="joystick-handle" id="joystickHandle"></div>
                 </div>
-                <button class="start-btn" id="startBtn">START</button>
             </div>
         </div>
         


### PR DESCRIPTION
Fixes mobile joystick unresponsiveness and swaps its position with the START button for improved usability.

The joystick's `touchmove` and `touchend` events were previously bound only to its container, causing it to stop responding when a finger dragged outside the joystick area. This change moves these listeners to the `document` level and introduces `touchStartedOnJoystick` to correctly track and handle touch interactions, ensuring continuous control. Additionally, the joystick can now queue directional input even before the game officially starts.

---
<a href="https://cursor.com/background-agent?bcId=bc-b231bc67-7bc5-40c3-b521-ab1348da69a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b231bc67-7bc5-40c3-b521-ab1348da69a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

